### PR TITLE
Improved the slide effect of the showcase component & bugfix

### DIFF
--- a/app/locales/en_EN.json
+++ b/app/locales/en_EN.json
@@ -386,7 +386,7 @@
         },
         "apps": {
             "anchor": "App samples",
-            "url": "/category/mobile-apps/"
+            "url": "/showcase/"
         },
         "create_apps": {
             "anchor": "We create your app",

--- a/app/scripts/app.js
+++ b/app/scripts/app.js
@@ -496,6 +496,9 @@ var ShowCase = {
     prevPage: function () {
         this.movePage(-1);
     },
+    _resetClasses: function (elem) {
+        elem.removeClass('hidden animated fadeInLeft fadeInRight fadeOutLeft fadeOutRight');
+    },
     /**
      * Moves the page to the given direction the number of positions given by dir
      * @method movePage
@@ -516,10 +519,24 @@ var ShowCase = {
             left: offset + 'px'
         });
 
-        this.showCategory(dir > 0);
+        var lastCategory = $(this.categories[this.lastPosition]),
+            initialWidth = lastCategory.css('width');
+        lastCategory.css({
+            float: 'left',
+            width: '100%'
+        });
+        
+        this._resetClasses(lastCategory);
+        lastCategory.addClass('animated ' + (dir > 0 ? 'fadeOutLeft' : 'fadeOutRight'));
+        lastCategory.one('webkitAnimationEnd mozAnimationEnd MSAnimationEnd oanimationend animationend', function () {
+            lastCategory.css({
+                width: initialWidth,
+                float: 'none'
+            });
+            lastCategory.addClass('hidden');
 
-        var category = $(this.categories[this.lastPosition]);
-        category.addClass('hidden');
+            this.showCategory(dir > 0);
+        }.bind(this));
     },
     /**
      * Show the current category
@@ -528,7 +545,7 @@ var ShowCase = {
      */
     showCategory: function (next) {
         var category = $(this.categories[this.currentPosition]);
-        category.removeClass('hidden animated fadeInLeft fadeInRight fadeOutLeft fadeOutRight');
+        this._resetClasses(category);
         category.addClass('animated ' + (next ? 'fadeInRight' : 'fadeInLeft'));
 
         if (!this.isHome) {
@@ -543,7 +560,7 @@ var ShowCase = {
         $(this.selectorBtns[this.currentPosition]).addClass('active');
     },
     /**
-     *
+     * Configures the showcase component
      * @method setup
      * @param {jQuery} $
      */


### PR DESCRIPTION
The slide effect of the showcase component now doesn't directly hide the latest category and the animate the new one, now it animates the disappearance of the latest category and then animates the appearance of the next one which is a nicer effect than the previous one. It has a bit of lag on the showcase page because of the 15 iframes but it's more smooth.

Also, with the english language turned on the showcase link on the header linked to the old blog and not the new showcase page. 